### PR TITLE
Fix nomad file to deploy only publishing group

### DIFF
--- a/dp-static-file-publisher.nomad
+++ b/dp-static-file-publisher.nomad
@@ -3,7 +3,7 @@ job "dp-static-file-publisher" {
   region      = "eu"
   type        = "service"
 
-  // Make sure that this API is only ran on the publishing nodes
+  // Make sure that this API runs on publishing nodes only
   constraint {
     attribute = "${node.class}"
     value     = "publishing"

--- a/dp-static-file-publisher.nomad
+++ b/dp-static-file-publisher.nomad
@@ -3,6 +3,12 @@ job "dp-static-file-publisher" {
   region      = "eu"
   type        = "service"
 
+  // Make sure that this API is only ran on the publishing nodes
+  constraint {
+    attribute = "${node.class}"
+    value     = "publishing"
+  }
+
   update {
     stagger          = "60s"
     min_healthy_time = "30s"
@@ -11,78 +17,9 @@ job "dp-static-file-publisher" {
     auto_revert      = true
   }
 
-  group "web" {
-    count = "{{WEB_TASK_COUNT}}"
-
-    constraint {
-      attribute = "${node.class}"
-      value     = "web"
-    }
-
-    restart {
-      attempts = 3
-      delay    = "15s"
-      interval = "1m"
-      mode     = "delay"
-    }
-
-    task "dp-static-file-publisher-web" {
-      driver = "docker"
-
-      artifact {
-        source = "s3::https://s3-eu-west-1.amazonaws.com/{{DEPLOYMENT_BUCKET}}/dp-static-file-publisher/{{PROFILE}}/{{RELEASE}}.tar.gz"
-      }
-
-      config {
-        command = "${NOMAD_TASK_DIR}/start-task"
-
-        args = ["./dp-static-file-publisher"]
-
-        image = "{{ECR_URL}}:concourse-{{REVISION}}"
-
-      }
-
-      service {
-        name = "dp-static-file-publisher"
-        port = "http"
-        tags = ["web"]
-
-        check {
-          type     = "http"
-          path     = "/health"
-          interval = "10s"
-          timeout  = "2s"
-        }
-      }
-
-      resources {
-        cpu    = "{{WEB_RESOURCE_CPU}}"
-        memory = "{{WEB_RESOURCE_MEM}}"
-
-        network {
-          port "http" {}
-        }
-      }
-
-      template {
-        source      = "${NOMAD_TASK_DIR}/vars-template"
-        destination = "${NOMAD_TASK_DIR}/vars"
-      }
-
-      vault {
-        policies = ["dp-static-file-publisher-web"]
-      }
-    }
-  }
-
   group "publishing" {
     count = "{{PUBLISHING_TASK_COUNT}}"
 
-    constraint {
-      attribute = "${node.class}"
-      value     = "publishing"
-    }
-
     restart {
       attempts = 3
       delay    = "15s"
@@ -90,7 +27,7 @@ job "dp-static-file-publisher" {
       mode     = "delay"
     }
 
-    task "dp-static-file-publisher-publishing" {
+    task "dp-static-file-publisher" {
       driver = "docker"
 
       artifact {
@@ -133,7 +70,7 @@ job "dp-static-file-publisher" {
       }
 
       vault {
-        policies = ["dp-static-file-publisher-publishing"]
+        policies = ["dp-static-file-publisher"]
       }
     }
   }


### PR DESCRIPTION
### What

This service is supposed to exist only in publishing mode. This PR contains the changes in the nomad file to make sure nomad only attempts to deploy the publishing group:
- removed web group
- renamed task and vault policies to the expected values 
- moved publishing constrain to the top level 
After this task is merged, the following CI failure should be fixed:
https://concourse.onsdigital.co.uk/teams/main/pipelines/dp-static-file-publisher/jobs/develop-ship-it/builds/1

### How to review

Make sure the changes in nomad file make sense

### Who can review

Anyone.
